### PR TITLE
Multi target Prospa.Extensions.AspNetCore.Http

### DIFF
--- a/src/Prospa.Extensions.AspNetCore.Http/Builder/ApplicationBuilderExtensions.cs
+++ b/src/Prospa.Extensions.AspNetCore.Http/Builder/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿#if NETCOREAPP
+using Microsoft.AspNetCore.Builder;
 using Prospa.Extensions.AspNetCore.Http.Middlewares;
 
 namespace Prospa.Extensions.AspNetCore.Http.Builder
@@ -13,3 +14,4 @@ namespace Prospa.Extensions.AspNetCore.Http.Builder
         }
     }
 }
+#endif

--- a/src/Prospa.Extensions.AspNetCore.Http/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Prospa.Extensions.AspNetCore.Http/Extensions/HeaderDictionaryExtensions.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿#if NETCOREAPP
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Primitives;
 
 // ReSharper disable CheckNamespace
 namespace Microsoft.AspNetCore.Http
-    // ReSharper restore CheckNamespace
+// ReSharper restore CheckNamespace
 {
     public static class HeaderDictionaryExtensions
     {
@@ -42,3 +43,4 @@ namespace Microsoft.AspNetCore.Http
         }
     }
 }
+#endif

--- a/src/Prospa.Extensions.AspNetCore.Http/Middlewares/DiagnosticActivityMiddleware.cs
+++ b/src/Prospa.Extensions.AspNetCore.Http/Middlewares/DiagnosticActivityMiddleware.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿#if NETCOREAPP
+using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -68,3 +69,4 @@ namespace Prospa.Extensions.AspNetCore.Http.Middlewares
         }
     }
 }
+#endif

--- a/src/Prospa.Extensions.AspNetCore.Http/Prospa.Extensions.AspNetCore.Http.csproj
+++ b/src/Prospa.Extensions.AspNetCore.Http/Prospa.Extensions.AspNetCore.Http.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core HTTP extensions.</Description>
-    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <PackageTags>prospa;http;extensions</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup Label="Framework References">
+  
+  <ItemGroup Label="Framework References" Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Prospa.Extensions.AspNetCore.Http/RequestDetail.cs
+++ b/src/Prospa.Extensions.AspNetCore.Http/RequestDetail.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if NETCOREAPP
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -44,3 +45,4 @@ namespace Prospa.Extensions.AspNetCore.Http
         public string QueryString { get; }
     }
 }
+#endif


### PR DESCRIPTION
We have some applications written in dotnet framework 472 that would require too mcuh work to upgrade to net core 3.1.

These changes allow them to benefit from the delegating handler middleware without upgrading.