### PR TITLE
downgrade netstandard version on Prospa.Extensions.ApplicationInsights

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <MinVerMinimumMajorMinor>2.2</MinVerMinimumMajorMinor>
-    <MinVerDefaultPreReleasePhase>preview4</MinVerDefaultPreReleasePhase>
+    <MinVerDefaultPreReleasePhase>preview5</MinVerDefaultPreReleasePhase>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Prospa.Extensions.ApplicationInsights/Prospa.Extensions.ApplicationInsights.csproj
+++ b/src/Prospa.Extensions.ApplicationInsights/Prospa.Extensions.ApplicationInsights.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <Description>Application Insights extensions.</Description>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <PackageTags>prospa;http;extensions</PackageTags>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageTags>prospa;http;extensions;diagnostics</PackageTags>
   </PropertyGroup>
 
   <ItemGroup Label="Microsoft References">


### PR DESCRIPTION
These changes make it possible to install this package on asp.net core 2.x project.