### PR TITLE
updating metric names in Datadog health check publisher

### DIFF
--- a/sandbox/Sandbox.Api/Startup.Health.cs
+++ b/sandbox/Sandbox.Api/Startup.Health.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Prospa.Extensions.Diagnostics.DDPublisher;
-using Prospa.Extensions.AspNetCore.Hosting;
 using Prospa.Extensions.Hosting;
 using Sandbox.Api.Application.HealthChecks;
 

--- a/src/Prospa.Extensions.Diagnostics.DDPublisher/DatadogConfiguration.cs
+++ b/src/Prospa.Extensions.Diagnostics.DDPublisher/DatadogConfiguration.cs
@@ -6,9 +6,6 @@ namespace Prospa.Extensions.Diagnostics.DDPublisher
     public class DatadogConfiguration
     {
         [Required]
-        public string Url { get; set; }
-
-        [Required]
         public string ApiKey { get; set; }
 
         [Required]
@@ -16,9 +13,14 @@ namespace Prospa.Extensions.Diagnostics.DDPublisher
 
         public string[] DefaultTags { get; set; } = Array.Empty<string>();
 
+        public string MetricNamePrefix { get; set; }
+
         [Required]
         public string ServiceCheckName { get; set; }
 
         public string ServiceTagPrefix { get; set; } = "check";
+
+        [Required]
+        public string Url { get; set; }
     }
 }

--- a/src/Prospa.Extensions.Diagnostics.DDPublisher/DatadogPublisher.cs
+++ b/src/Prospa.Extensions.Diagnostics.DDPublisher/DatadogPublisher.cs
@@ -29,6 +29,9 @@ namespace Prospa.Extensions.Diagnostics.DDPublisher
 
                 var key = keyedEntry.Key;
                 var entry = keyedEntry.Value;
+                var metricName = !string.IsNullOrWhiteSpace(_configuration.MetricNamePrefix)
+                    ? $"{_configuration.MetricNamePrefix}.{key.Replace(' ', '_')}"
+                    : key.Replace(' ', '_');
 
                 var dataDogStatus = entry.Status switch
                 {
@@ -46,7 +49,7 @@ namespace Prospa.Extensions.Diagnostics.DDPublisher
                                 $"{_configuration.ServiceTagPrefix}:{key}"
                            }).ToArray();
 
-                metric.AddMetric(entry.Description, (int)dataDogStatus, (long)entry.Duration.TotalMilliseconds, tags);
+                metric.AddMetric(metricName, (int)dataDogStatus, (long)entry.Duration.TotalMilliseconds, tags);
             }
 
             await _client.SendMetricsAsync(metric);


### PR DESCRIPTION
DataDog Health Check publisher updates:

- Allows defining a metric name prefix to avoid clashes between apps and better exploration of metrics
- Uses the health check name as the metric name rather than description which can be fairly long