### PR TITLE
Target serilog library to .Net Standard 2.0

### DIFF
--- a/src/Prospa.Extensions.Serilog/Prospa.Extensions.Serilog.csproj
+++ b/src/Prospa.Extensions.Serilog/Prospa.Extensions.Serilog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Serilog extensions and enrichers.</Description>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>prospa;serilog</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
Enable this package to be used on Full Framework projects