### PR TITLE
decouple health report mapping from HttpContext

### DIFF
--- a/src/Prospa.Extensions.Hosting/ProspaConstants.cs
+++ b/src/Prospa.Extensions.Hosting/ProspaConstants.cs
@@ -14,39 +14,45 @@ namespace Prospa.Extensions.Hosting
         {
             context.Response.ContentType = "application/json; charset=utf-8";
 
+            var resultBytes = result.ToByteArray();
+
+            var json = Encoding.UTF8.GetString(resultBytes);
+
+            return context.Response.WriteAsync(json);
+        }
+
+        public static byte[] ToByteArray(this HealthReport report)
+        {
             var options = new JsonWriterOptions { Indented = true };
 
             using var stream = new MemoryStream();
-            using (var writer = new Utf8JsonWriter(stream, options))
+            using var writer = new Utf8JsonWriter(stream, options);
+
+            writer.WriteStartObject();
+            writer.WriteString("status", report.Status.ToString());
+            writer.WriteStartObject("results");
+
+            foreach (var entry in report.Entries)
             {
-                writer.WriteStartObject();
-                writer.WriteString("status", result.Status.ToString());
-                writer.WriteStartObject("results");
+                writer.WriteStartObject(entry.Key);
+                writer.WriteString("status", entry.Value.Status.ToString());
+                writer.WriteString("description", entry.Value.Description);
+                writer.WriteStartObject("data");
 
-                foreach (var entry in result.Entries)
+                foreach (var item in entry.Value.Data)
                 {
-                    writer.WriteStartObject(entry.Key);
-                    writer.WriteString("status", entry.Value.Status.ToString());
-                    writer.WriteString("description", entry.Value.Description);
-                    writer.WriteStartObject("data");
-
-                    foreach (var item in entry.Value.Data)
-                    {
-                        writer.WritePropertyName(item.Key);
-                        JsonSerializer.Serialize(writer, item.Value, item.Value?.GetType() ?? typeof(object));
-                    }
-
-                    writer.WriteEndObject();
-                    writer.WriteEndObject();
+                    writer.WritePropertyName(item.Key);
+                    JsonSerializer.Serialize(writer, item.Value, item.Value?.GetType() ?? typeof(object));
                 }
 
                 writer.WriteEndObject();
                 writer.WriteEndObject();
             }
 
-            var json = Encoding.UTF8.GetString(stream.ToArray());
+            writer.WriteEndObject();
+            writer.WriteEndObject();
 
-            return context.Response.WriteAsync(json);
+            return stream.ToArray();
         }
 
         public static class Environments


### PR DESCRIPTION
It is not possible to use the method on an Owin app, decided to expose the mapping as an extension to be reused on Full Framework applications.